### PR TITLE
[1.0.1] Fix callback in loader (fixes callback already called error).

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const compiler = require("c-preprocessor");
 
 module.exports = function(source) {
   const options = loaderUtils.getOptions(this);
+  const callback = this.async();
   compiler.compile(source, options, (err, result) => {
     this.callback(err, result);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-preprocessor-loader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Webpack loader for passing code through c-preprocessor",
   "main": "index.js",
   "repository": "https://github.com/FruitieX/c-preprocessor-loader",


### PR DESCRIPTION
Adds the creation of the loader callback, without this the loader just throws `Error: callback(): The callback was already called.`.

